### PR TITLE
Fix route validators imports

### DIFF
--- a/src/routes/authRoutes.js
+++ b/src/routes/authRoutes.js
@@ -1,13 +1,13 @@
 const router = require('express').Router();
 const passport = require('passport');
 const authController = require('../controllers/authController');
-const validators = require('../middleware/validators');
+const { authValidators } = require('../middleware/validators');
 
 // Register
-router.post('/register', validators.register, authController.register);
+router.post('/register', authValidators.register, authController.register);
 
 // Login
-router.post('/login', validators.login, authController.login);
+router.post('/login', authValidators.login, authController.login);
 
 // Google OAuth
 router.get('/google', 

--- a/src/routes/vocabularyRoutes.js
+++ b/src/routes/vocabularyRoutes.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const vocabularyController = require('../controllers/vocabularyController');
 const { authenticateJWT, optionalAuth } = require('../middleware/authMiddleware');
-const validators = require('../middleware/validators');
+const { vocabularyValidators } = require('../middleware/validators');
 
 // Public routes (optional auth for personalized data)
 router.get('/', optionalAuth, vocabularyController.getLists);
@@ -10,7 +10,7 @@ router.get('/:id', optionalAuth, vocabularyController.getList);
 // Protected routes
 router.use(authenticateJWT); // Apply auth to all routes below
 
-router.post('/', validators.createVocabularyList, vocabularyController.createList);
+router.post('/', vocabularyValidators.createList, vocabularyController.createList);
 router.put('/:id', vocabularyController.updateList);
 router.delete('/:id', vocabularyController.deleteList);
 router.post('/:listId/words', vocabularyController.addWord);


### PR DESCRIPTION
## Summary
- correctly import validators in auth and vocabulary routes

## Testing
- `npm test` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_685b47cba69c83269950236494f72575