### PR TITLE
Fix tests loading env

### DIFF
--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const request = require('supertest');
 const app = require('../src/app');
 


### PR DESCRIPTION
## Summary
- load `.env` first in `tests/auth.test.js`

## Testing
- `npm test` *(fails: Cannot find module '../services/cacheService')*

------
https://chatgpt.com/codex/tasks/task_b_685b567ea96c83269f8c5411554c831e