### PR TITLE
Fix nodemailer transport initialization

### DIFF
--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 class EmailService {
   constructor() {
-    this.transporter = nodemailer.createTransporter({
+    this.transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST,
       port: process.env.SMTP_PORT,
       secure: process.env.SMTP_SECURE === 'true',


### PR DESCRIPTION
## Summary
- use `nodemailer.createTransport` in the email service

## Testing
- `npm test` *(fails: `supabaseUrl is required`)*

------
https://chatgpt.com/codex/tasks/task_b_685b568475ec83268c2f9a551cb9447d