### PR TITLE
Implement validation schemas

### DIFF
--- a/src/models/schemas/auth/PasswordSchema.js
+++ b/src/models/schemas/auth/PasswordSchema.js
@@ -1,9 +1,6 @@
-// models/schemas/auth/PasswordSchema.js
 const { body, validationResult } = require('express-validator');
 
 class PasswordSchema {
-    
-    // Validation error handler
     static handleValidationErrors(req, res, next) {
         const errors = validationResult(req);
         if (!errors.isEmpty()) {
@@ -20,44 +17,48 @@ class PasswordSchema {
         next();
     }
 
-    // Basic password validation
     static basicPassword(field = 'password') {
         return body(field)
             .isLength({ min: 8, max: 128 })
             .withMessage('Password must be between 8-128 characters')
             .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/)
-            .withMessage('Password must contain at least one uppercase letter, one lowercase letter, and one number');
+            .withMessage('Password must contain uppercase, lowercase and number');
     }
 
-    // Strong password validation
     static strongPassword(field = 'password') {
         return body(field)
             .isLength({ min: 8, max: 128 })
             .withMessage('Password must be between 8-128 characters')
             .matches(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])/)
-            .withMessage('Password must contain uppercase, lowercase, number, and special character (@$!%*?&)')
+            .withMessage('Password must contain uppercase, lowercase, number and special character')
             .not()
             .matches(/(.)\1{2,}/)
             .withMessage('Password cannot contain more than 2 consecutive identical characters')
             .custom((value, { req }) => {
-                // Check against common weak passwords
                 const commonPasswords = [
                     'password', 'password123', '12345678', 'qwerty', 'abc123',
                     'Password1', 'admin123', 'welcome123', 'letmein123'
                 ];
-                
                 if (commonPasswords.includes(value.toLowerCase())) {
-                    throw new Error('Password is too common and easily guessable');
+                    throw new Error('Password is too common');
                 }
-
-                // Check if password contains parts of email
                 if (req.body.email) {
-                    const emailParts = req.body.email.split('@')[0].toLowerCase();
-                    if (value.toLowerCase().includes(emailParts) && emailParts.length > 3) {
-                        throw new Error('Password should not contain parts of your email address');
+                    const emailPart = req.body.email.split('@')[0].toLowerCase();
+                    if (emailPart.length > 3 && value.toLowerCase().includes(emailPart)) {
+                        throw new Error('Password should not contain parts of your email');
                     }
                 }
-
-                // Check if password contains parts of name
                 if (req.body.fullName) {
-                    const nameParts = req.body.fullName.toLowerCase
+                    const parts = req.body.fullName.toLowerCase().split(/\s+/);
+                    for (const part of parts) {
+                        if (part.length > 3 && value.toLowerCase().includes(part)) {
+                            throw new Error('Password should not contain parts of your name');
+                        }
+                    }
+                }
+                return true;
+            });
+    }
+}
+
+module.exports = PasswordSchema;

--- a/src/models/schemas/auth/TokenSchema.js
+++ b/src/models/schemas/auth/TokenSchema.js
@@ -1,0 +1,52 @@
+const { body, query, param, validationResult } = require('express-validator');
+
+class TokenSchema {
+    static handleValidationErrors(req, res, next) {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            return res.status(400).json({
+                success: false,
+                error: 'Validation failed',
+                details: errors.array().map(err => ({
+                    field: err.param,
+                    message: err.msg,
+                    value: err.value
+                }))
+            });
+        }
+        next();
+    }
+
+    static jwt(field = 'token') {
+        return body(field)
+            .notEmpty()
+            .withMessage(`${field} is required`)
+            .isJWT()
+            .withMessage(`Invalid ${field} format`);
+    }
+
+    static refreshToken(field = 'refreshToken') {
+        return body(field)
+            .notEmpty()
+            .withMessage('Refresh token is required')
+            .isJWT()
+            .withMessage('Invalid refresh token format');
+    }
+
+    static paramToken(field = 'token') {
+        return param(field)
+            .notEmpty()
+            .withMessage(`${field} is required`)
+            .isJWT()
+            .withMessage(`Invalid ${field} format`);
+    }
+
+    static queryToken(field = 'token') {
+        return query(field)
+            .optional()
+            .isJWT()
+            .withMessage(`Invalid ${field} format`);
+    }
+}
+
+module.exports = TokenSchema;

--- a/src/models/schemas/common/CommonSchema.js
+++ b/src/models/schemas/common/CommonSchema.js
@@ -1,0 +1,32 @@
+const { query, param, validationResult } = require('express-validator');
+const PaginationSchema = require('./PaginationSchema');
+
+class CommonSchema {
+    static handleValidationErrors(req, res, next) {
+        const errors = validationResult(req);
+        if (!errors.isEmpty()) {
+            return res.status(400).json({
+                success: false,
+                error: 'Validation failed',
+                details: errors.array().map(err => ({
+                    field: err.param,
+                    message: err.msg,
+                    value: err.value
+                }))
+            });
+        }
+        next();
+    }
+
+    static idParam(field = 'id') {
+        return param(field)
+            .isUUID()
+            .withMessage('Invalid ID format');
+    }
+
+    static paginationSchema(options = {}) {
+        return PaginationSchema.pagination(options);
+    }
+}
+
+module.exports = CommonSchema;

--- a/src/models/schemas/common/DateTimeSchema.js
+++ b/src/models/schemas/common/DateTimeSchema.js
@@ -1,0 +1,13 @@
+const { body, query } = require('express-validator');
+
+class DateTimeSchema {
+    static isoDate(field, location = 'body') {
+        const validator = location === 'query' ? query(field) : body(field);
+        return validator
+            .isISO8601()
+            .withMessage(`${field} must be a valid ISO8601 date`)
+            .toDate();
+    }
+}
+
+module.exports = DateTimeSchema;

--- a/src/models/schemas/common/PaginationSchema.js
+++ b/src/models/schemas/common/PaginationSchema.js
@@ -1,0 +1,20 @@
+const { query } = require('express-validator');
+
+class PaginationSchema {
+    static pagination({ maxLimit = 100 } = {}) {
+        return [
+            query('page')
+                .optional()
+                .isInt({ min: 1 })
+                .withMessage('Page must be a positive integer')
+                .toInt(),
+            query('limit')
+                .optional()
+                .isInt({ min: 1, max: maxLimit })
+                .withMessage(`Limit must be between 1 and ${maxLimit}`)
+                .toInt()
+        ];
+    }
+}
+
+module.exports = PaginationSchema;


### PR DESCRIPTION
## Summary
- implement complex password validator
- add token validation helper
- create common base schema with pagination helpers
- provide DateTime and pagination schemas

## Testing
- `npm install`
- `npm test` *(fails: Cannot find config modules)*

------
https://chatgpt.com/codex/tasks/task_b_685e951b2db88326bd8ede9adecf0630